### PR TITLE
Use url instead of baseurl for disqus JS script

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -7,7 +7,7 @@
   */
 
   var disqus_config = function () {
-    this.page.url = "{{ site.baseurl }}" + "{{ page.url }}";
+    this.page.url = "{{ site.url }}" + "{{ page.url }}";
     this.page.identifier = "{{ page.id }}";
   };
 


### PR DESCRIPTION
## Related Issue

Fix #2 
## Description
- use url instead of baseurl
